### PR TITLE
Use Python 3.10 for the motivation vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: basilisk
-Version: 1.11.2
-Date: 2022-11-08
+Version: 1.11.3
+Date: 2023-03-15
 Title: Freezing Python Dependencies Inside Bioconductor Packages
 Authors@R: c(person("Aaron", "Lun", role=c("aut", "cre", "cph"),
         email="infinite.monkeys.with.keyboards@gmail.com"),

--- a/vignettes/motivation.Rmd
+++ b/vignettes/motivation.Rmd
@@ -302,7 +302,7 @@ if (!file.exists(tmp2)) {
         basilisk.utils::getCondaDir(), 
         basilisk.utils::getCondaBinary()
     )
-    conda_install(tmp2, packages=c("scipy==1.9.1"), python_version="3.8", conda=conda.bin)
+    conda_install(tmp2, packages=c("scipy==1.9.1"), python_version="3.10", conda=conda.bin)
 }
 
 basiliskRun(env=tmp2, fun=function(mat) {


### PR DESCRIPTION
Fixes #22

The 3.8 one fails on Linux ARM64 due to:
`reticulate can only bind to copies of Python built with '--enable-shared'`