### PR TITLE
Explicitly attach reticulate from the right library

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: basilisk
-Version: 1.13.1
-Date: 2023-06-07
+Version: 1.13.2
+Date: 2023-06-30
 Title: Freezing Python Dependencies Inside Bioconductor Packages
 Authors@R: c(person("Aaron", "Lun", role=c("aut", "cre", "cph"),
         email="infinite.monkeys.with.keyboards@gmail.com"),

--- a/R/basiliskStart.R
+++ b/R/basiliskStart.R
@@ -203,7 +203,9 @@ basiliskStart <- function(env, fork=getBasiliskFork(), shared=getBasiliskShared(
         clusterCall(proc, assigner, name="isWindows", value=isWindows)
         clusterCall(proc, activateEnvironment, envpath=envpath, loc=getCondaDir())
         clusterCall(proc, assigner, name="activateEnvironment", value=function(...) {}) # no-op as we already ran it.
-        clusterCall(proc, attachNamespace, ns="reticulate")
+        clusterCall(proc, function() {
+            library("reticulate", character.only=TRUE, lib.loc = file.path(R.home(), "library"))
+        })
 
         clusterCall(proc, useBasiliskEnv, envpath=envpath)
         clusterCall(proc, .instantiate_store)


### PR DESCRIPTION
Explicitly attach reticulate from the right library in the fallback environment.
Addresses [https://github.com/LTLA/basilisk.utils/issues/8](https://github.com/LTLA/basilisk.utils/issues/8)
I did not include a version bump, assuming that this might go in both release and devel (at least that would be helpful for us 🙂). 