### PR TITLE
Commented on the licensing problems with the defaults channel.

### DIFF
--- a/R/BasiliskEnvironment.R
+++ b/R/BasiliskEnvironment.R
@@ -14,7 +14,8 @@
 #' \item \code{pkgname}, string containing the name of the package that owns the environment.
 #' \item \code{packages}, character vector containing the names of the required Python packages from conda,
 #' see \code{\link{setupBasiliskEnv}} for requirements.
-#' \item \code{channels}, character vector specifying the Conda channels to search.
+#' \item \code{channels}, character vector specifying the Conda channels to search,
+#' see \code{\link{setupBasiliskEnv}} for detials.
 #' \item \code{pip}, character vector containing names of additional Python packages from PyPi,
 #' see \code{\link{setupBasiliskEnv}} for requirements.
 #' \item \code{paths}, character vector containing relative paths to Python packages to be installed via \code{pip}.

--- a/R/setupBasiliskEnv.R
+++ b/R/setupBasiliskEnv.R
@@ -5,7 +5,7 @@
 #' @param envpath String containing the path to the environment to use. 
 #' @param packages Character vector containing the names of conda packages to install into the environment.
 #' Version numbers must be included.
-#' @param channels Character vector containing the names of additional conda channels to search.
+#' @param channels Character vector containing the names of Conda channels to search.
 #' Defaults to the conda-forge repository.
 #' @param pip Character vector containing the names of additional packages to install from PyPi using \code{pip}.
 #' Version numbers must be included.
@@ -16,7 +16,7 @@
 #' A \code{NULL} is invisibly returned.
 #'
 #' @details
-#' Developers of client packages should never need to call this function directly.
+#' Developers of \pkg{basilisk} client packages should never need to call this function directly.
 #' For typical usage, \code{setupBasiliskEnv} is automatically called by \code{\link{basiliskStart}} to perform lazy installation.
 #' Developers should also create \code{configure(.win)} files to call \code{\link{configureBasiliskEnv}},
 #' which will call \code{setupBasiliskEnv} during R package installation when \code{BASILISK_USE_SYSTEM_DIR=1}.
@@ -24,6 +24,11 @@
 #' Pinned version numbers must be present for all desired conda packages in \code{packages}.
 #' This improves predictability and simplifies debugging across different systems.
 #' Note that the version notation for conda packages uses a single \code{=}, while the notation for Python packages uses \code{==}; any instances of the latter will be coerced to the former automatically.
+#'
+#' For \code{channels}, we recommend using open-source repositories like conda-forge and bioconda.
+#' This avoids problems with non-open-source licensing of the main Anaconda repositories (i.e., the \code{"defaults"} channel).
+#' If a client package relies on non-free channels, its users may inadvertently violate the Anaconda license,
+#' e.g., when used in a commercial environment.
 #'
 #' It is possible to use the \code{pip} argument to install additional packages from PyPi after all the conda packages are installed.
 #' All packages listed here are also expected to have pinned versions, this time using the \code{==} notation.

--- a/man/BasiliskEnvironment-class.Rd
+++ b/man/BasiliskEnvironment-class.Rd
@@ -19,7 +19,8 @@ Environment names starting with an underscore are reserved for internal use.
 \item \code{pkgname}, string containing the name of the package that owns the environment.
 \item \code{packages}, character vector containing the names of the required Python packages from conda,
 see \code{\link{setupBasiliskEnv}} for requirements.
-\item \code{channels}, character vector specifying the Conda channels to search.
+\item \code{channels}, character vector specifying the Conda channels to search,
+see \code{\link{setupBasiliskEnv}} for detials.
 \item \code{pip}, character vector containing names of additional Python packages from PyPi,
 see \code{\link{setupBasiliskEnv}} for requirements.
 \item \code{paths}, character vector containing relative paths to Python packages to be installed via \code{pip}.

--- a/man/setupBasiliskEnv.Rd
+++ b/man/setupBasiliskEnv.Rd
@@ -18,7 +18,7 @@ setupBasiliskEnv(
 \item{packages}{Character vector containing the names of conda packages to install into the environment.
 Version numbers must be included.}
 
-\item{channels}{Character vector containing the names of additional conda channels to search.
+\item{channels}{Character vector containing the names of Conda channels to search.
 Defaults to the conda-forge repository.}
 
 \item{pip}{Character vector containing the names of additional packages to install from PyPi using \code{pip}.
@@ -34,7 +34,7 @@ A \code{NULL} is invisibly returned.
 Set up a conda environment for isolated execution of Python code with appropriate versions of all Python packages.
 }
 \details{
-Developers of client packages should never need to call this function directly.
+Developers of \pkg{basilisk} client packages should never need to call this function directly.
 For typical usage, \code{setupBasiliskEnv} is automatically called by \code{\link{basiliskStart}} to perform lazy installation.
 Developers should also create \code{configure(.win)} files to call \code{\link{configureBasiliskEnv}},
 which will call \code{setupBasiliskEnv} during R package installation when \code{BASILISK_USE_SYSTEM_DIR=1}.
@@ -42,6 +42,11 @@ which will call \code{setupBasiliskEnv} during R package installation when \code
 Pinned version numbers must be present for all desired conda packages in \code{packages}.
 This improves predictability and simplifies debugging across different systems.
 Note that the version notation for conda packages uses a single \code{=}, while the notation for Python packages uses \code{==}; any instances of the latter will be coerced to the former automatically.
+
+For \code{channels}, we recommend using open-source repositories like conda-forge and bioconda.
+This avoids problems with non-open-source licensing of the main Anaconda repositories (i.e., the \code{"defaults"} channel).
+If a client package relies on non-free channels, its users may inadvertently violate the Anaconda license,
+e.g., when used in a commercial environment.
 
 It is possible to use the \code{pip} argument to install additional packages from PyPi after all the conda packages are installed.
 All packages listed here are also expected to have pinned versions, this time using the \code{==} notation.

--- a/vignettes/motivation.Rmd
+++ b/vignettes/motivation.Rmd
@@ -77,6 +77,10 @@ Otherwise, `r Biocpkg("basilisk")` will automatically use the `conda`-provided v
 It is often a good idea to explicitly list a version of Python in `packages=`, even if it is already version-compatible with the default;
 this ensures that the environment creation is robust to adminstrator overrides of the conda instance (see [below](#fine-tuning-basilisks-behavior)).
 
+By default, `r Biocpkg("basilisk")` will fetch Conda packages from the `conda-forge` channel (see `setupBasiliskEnv()` for details).
+This can be modified through the `channels=` argument in the `BasiliskEnvironment()` constructor, though some care is required with respect to licensing.
+In particular, the default Anaconda channel (i.e.,`defaults`) is not free for commercial usage, which restricts the usability of any Bioconductor packages that use Conda packages from this channel.
+
 It is also possible to install packages from PyPi via the `pip=` argument,
 but this should be done with [much caution](https://www.anaconda.com/blog/using-pip-in-a-conda-environment).
 


### PR DESCRIPTION
The `defaults` packages haven't been free to use for a long time, which makes it difficult to use any default-dependent Bioconductor packages in commercial settings. Perhaps a more general notification to affected packages (e.g., FLAMES) would also be helpful if they can be persuaded to drop `defaults`.